### PR TITLE
Add 'startAfterDocument' option, bump version to 0.1.1

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -190,7 +190,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   path:
     dependency: transitive
     description:

--- a/lib/bloc/pagination_bloc.dart
+++ b/lib/bloc/pagination_bloc.dart
@@ -10,11 +10,12 @@ part 'pagination_event.dart';
 part 'pagination_state.dart';
 
 class PaginationBloc extends Bloc<PaginationEvent, PaginationState> {
-  PaginationBloc(this._query, this._limit);
+  PaginationBloc(this._query, this._limit, this._startAfterDocument);
 
   DocumentSnapshot _lastDocument;
   final Query _query;
   final int _limit;
+  final DocumentSnapshot _startAfterDocument;
 
   @override
   Stream<PaginationState> mapEventToState(
@@ -58,6 +59,8 @@ class PaginationBloc extends Bloc<PaginationEvent, PaginationState> {
   Future<List<DocumentSnapshot>> _getDocumentSnapshots() async {
     final localQuery = (_lastDocument != null)
         ? _query.startAfterDocument(_lastDocument)
+        : _startAfterDocument != null
+        ? _query.startAfterDocument(_startAfterDocument)
         : _query;
     try {
       final querySnapshot = await localQuery.limit(_limit).getDocuments();

--- a/lib/paginate_firestore.dart
+++ b/lib/paginate_firestore.dart
@@ -16,6 +16,7 @@ class PaginateFirestore extends StatefulWidget {
     Key key,
     @required this.itemBuilder,
     @required this.query,
+    this.startAfterDocument,
     this.itemsPerPage = 15,
     this.onError,
     this.emptyDisplay = const EmptyDisplay(),
@@ -35,6 +36,7 @@ class PaginateFirestore extends StatefulWidget {
   final Widget emptyDisplay;
   final ScrollPhysics physics;
   final Query query;
+  final DocumentSnapshot startAfterDocument;
   final bool reverse;
   final Axis scrollDirection;
   final Widget separator;
@@ -77,7 +79,11 @@ class _PaginateFirestoreState extends State<PaginateFirestore> {
   @override
   void initState() {
     super.initState();
-    _bloc = PaginationBloc(widget.query, widget.itemsPerPage)..add(PageFetch());
+    _bloc = PaginationBloc(
+      widget.query,
+      widget.itemsPerPage,
+      widget.startAfterDocument,
+    )..add(PageFetch());
   }
 
   Widget _buildListView(PaginationLoaded loadedState) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: paginate_firestore
 description: A flutter package to simplify pagination with firestore data.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/excogitatr/paginate_firestore
 issue_tracker: https://github.com/excogitatr/paginate_firestore/issues
 


### PR DESCRIPTION
Thanks for the package - it's working great for me so far!

I needed the ability to use `startAfterDocument` in the initial query. There is certainly a better way to go about this, but this is all I required.  Figured I would share with you anyways.