### PR TITLE
added onReachedEnd handler and filter listener

### DIFF
--- a/lib/bloc/pagination_bloc.dart
+++ b/lib/bloc/pagination_bloc.dart
@@ -48,6 +48,26 @@ class PaginationBloc extends Bloc<PaginationEvent, PaginationState> {
         }
       }
     }
+    if (event is PageFiltered) {
+      if (state is PaginationLoaded) {
+        PaginationLoaded currentState = state as PaginationLoaded;
+        List<DocumentSnapshot> filteredItems = currentState.documentSnapshots.where((document) {
+          bool hasFilter = false;
+          document.data().forEach((key, value) {
+            if (value.toString().contains(event.filter)) {
+              hasFilter = true;
+            }
+          });
+          return hasFilter;
+        }).toList();
+
+        yield PaginationLoaded(
+            documentSnapshots: filteredItems,
+            hasReachedEnd: currentState.hasReachedEnd
+        );
+      }
+    }
+
     if (event is PageRefreshed) {
       _lastDocument = null;
 
@@ -56,8 +76,6 @@ class PaginationBloc extends Bloc<PaginationEvent, PaginationState> {
         documentSnapshots: firstItems,
         hasReachedEnd: firstItems.isEmpty,
       );
-
-      //yield PaginationInitial();
     }
   }
 

--- a/lib/bloc/pagination_event.dart
+++ b/lib/bloc/pagination_event.dart
@@ -6,3 +6,9 @@ abstract class PaginationEvent {}
 class PageFetch implements PaginationEvent {}
 
 class PageRefreshed implements PaginationEvent {}
+
+class PageFiltered implements PaginationEvent {
+  final String filter;
+
+  PageFiltered(this.filter);
+}

--- a/lib/bloc/pagination_listeners.dart
+++ b/lib/bloc/pagination_listeners.dart
@@ -19,19 +19,19 @@ class PaginateRefreshedChangeListener extends PaginateChangeListener {
   }
 }
 
-class PaginateSearchChangeListener extends PaginateChangeListener {
-  String _searchTerm;
+class PaginateFilterChangeListener extends PaginateChangeListener {
+  String _filterTerm;
 
-  PaginateSearchChangeListener();
+  PaginateFilterChangeListener();
 
   set search(String value) {
-    _searchTerm = value;
+    _filterTerm = value;
     if (value.isNotEmpty) {
       notifyListeners();
     }
   }
 
-  String get search {
-    return _searchTerm;
+  String get filter {
+    return _filterTerm;
   }
 }

--- a/lib/paginate_firestore.dart
+++ b/lib/paginate_firestore.dart
@@ -25,6 +25,7 @@ class PaginateFirestore extends StatefulWidget {
     this.itemsPerPage = 15,
     this.onError,
     this.onReachedEnd,
+    this.onLoaded,
     this.emptyDisplay = const EmptyDisplay(),
     this.separator = const EmptySeparator(),
     this.initialLoader = const InitialLoader(),
@@ -63,6 +64,7 @@ class PaginateFirestore extends StatefulWidget {
   final Widget Function(int, BuildContext, DocumentSnapshot) itemBuilder;
 
   final void Function(PaginationLoaded) onReachedEnd;
+  final void Function(PaginationLoaded) onLoaded;
 }
 
 class _PaginateFirestoreState extends State<PaginateFirestore> {
@@ -83,7 +85,10 @@ class _PaginateFirestoreState extends State<PaginateFirestore> {
         } else {
           PaginationLoaded loadedState = state as PaginationLoaded;
 
-          if (loadedState.hasReachedEnd) {
+          if (widget.onLoaded != null) {
+            widget.onLoaded(loadedState);
+          }
+          if (loadedState.hasReachedEnd && widget.onReachedEnd != null) {
             widget.onReachedEnd(loadedState);
           }
 


### PR DESCRIPTION
The onReachedEnd function receives a state reference of type PaginationLoaded when the list came to an end. With this reference you can access the list of documents, for example:

```dart
onReachedEnd: (state) {
    List<DocumentSnapshot> documents = state.documentSnapshots;
}
```

You can filter cached list items using a listener of type PaginateFilterChangeListener, like this:

```dart
PaginateFilterChangeListener filterChangeListener = PaginateFilterChangeListener();

...
    listeners: [
        searchChangeListener
    ],
...

filterChangeListener.filter = "my_filter_string";
```