### PR TITLE
Change type of 'itemBuilderType' from dynamic to PaginateBuilderType

### DIFF
--- a/lib/paginate_firestore.dart
+++ b/lib/paginate_firestore.dart
@@ -48,7 +48,7 @@ class PaginateFirestore extends StatefulWidget {
   final Widget emptyDisplay;
   final SliverGridDelegate gridDelegate;
   final Widget initialLoader;
-  final dynamic itemBuilderType;
+  final PaginateBuilderType itemBuilderType;
   final int itemsPerPage;
   final List<ChangeNotifier> listeners;
   final EdgeInsets padding;


### PR DESCRIPTION
I think the type of itemBuilderType is PaginateBuilderType, not dynamic.
Please let me know if I misunderstand the usage of itemBuilderType!
Thanks!