### PR TITLE
Cancel stream listener

### DIFF
--- a/lib/bloc/pagination_cubit.dart
+++ b/lib/bloc/pagination_cubit.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
@@ -18,6 +20,8 @@ class PaginationCubit extends Cubit<PaginationState> {
   final Query _query;
   final DocumentSnapshot? _startAfterDocument;
   final bool isLive;
+
+  final List<StreamSubscription<QuerySnapshot>> _streams = List<StreamSubscription<QuerySnapshot>>();
 
   void filterPaginatedList(String searchTerm) {
     if (state is PaginationLoaded) {
@@ -42,9 +46,11 @@ class PaginationCubit extends Cubit<PaginationState> {
     _lastDocument = null;
     final localQuery = _getQuery();
     if (isLive) {
-      localQuery.snapshots().listen((querySnapshot) {
+      StreamSubscription<QuerySnapshot> listener = localQuery.snapshots().listen((querySnapshot) {
         _emitPaginatedState(querySnapshot.docs);
       });
+
+      _streams.add(listener);
     } else {
       final querySnapshot = await localQuery.get();
       _emitPaginatedState(querySnapshot.docs);
@@ -83,13 +89,15 @@ class PaginationCubit extends Cubit<PaginationState> {
     } else if (state is PaginationLoaded) {
       final loadedState = state as PaginationLoaded;
       if (loadedState.hasReachedEnd) return;
-      localQuery.snapshots().listen((querySnapshot) {
+      StreamSubscription<QuerySnapshot> listener =  localQuery.snapshots().listen((querySnapshot) {
         _emitPaginatedState(
           querySnapshot.docs,
           previousList:
               loadedState.documentSnapshots as List<QueryDocumentSnapshot>,
         );
       });
+
+      _streams.add(listener);
     }
   }
 
@@ -113,5 +121,9 @@ class PaginationCubit extends Cubit<PaginationState> {
             : _query;
     localQuery = localQuery.limit(_limit);
     return localQuery;
+  }
+
+  void dispose() {
+    _streams.forEach((listener) => listener.cancel());
   }
 }

--- a/lib/paginate_firestore.dart
+++ b/lib/paginate_firestore.dart
@@ -115,6 +115,7 @@ class _PaginateFirestoreState extends State<PaginateFirestore> {
   @override
   void dispose() {
     _scrollController.dispose();
+    _cubit.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
When using the option `isLive: true`, the stream always opens even we navigate to another screen.
With this PR, automatically gathering all stream listeners and cancel it on `dispose()`.