### PR TITLE
Remove printing of newList length

### DIFF
--- a/lib/bloc/pagination_cubit.dart
+++ b/lib/bloc/pagination_cubit.dart
@@ -105,7 +105,6 @@ class PaginationCubit extends Cubit<PaginationState> {
     List<QueryDocumentSnapshot> newList, {
     List<QueryDocumentSnapshot> previousList = const [],
   }) {
-    print(newList.length);
     _lastDocument = newList.isNotEmpty ? newList.last : null;
     emit(PaginationLoaded(
       documentSnapshots: previousList + newList,


### PR DESCRIPTION
I was really confused when I saw entries in my console which I couldn't pin down in my code. 