### PR TITLE
Fix: ScrollController not attaching to the PaginateFirestore widget

### DIFF
--- a/lib/paginate_firestore.dart
+++ b/lib/paginate_firestore.dart
@@ -196,6 +196,7 @@ class _PaginateFirestoreState extends State<PaginateFirestore> {
   Widget _buildListView(PaginationLoaded loadedState) {
     var listView = CustomScrollView(
       reverse: widget.reverse,
+      controller: widget.scrollController,
       shrinkWrap: widget.shrinkWrap,
       scrollDirection: widget.scrollDirection,
       physics: widget.physics,


### PR DESCRIPTION
The scrollController parameter was never passed to the buildListView > CustomScrollView controller property